### PR TITLE
Removed bsg_printf.rvo from linking, making it optional

### DIFF
--- a/examples/hello_world/Makefile
+++ b/examples/hello_world/Makefile
@@ -58,10 +58,12 @@ VERSIONS = v0 v1 v2 v3
 # come up with your own solution.
 # 
 # Use KERNEL_INCLUDES to specify the path to directories that contain headers.
+#
+# If you want to use bsg_printf.c, you MUST include it in KERNEL_CLIBRARIES
 ################################################################################
 
 # C Libraries
-KERNEL_CLIBRARIES   +=
+KERNEL_CLIBRARIES   += $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_printf.c
 # C++ Libraries
 KERNEL_CXXLIBRARIES +=
 

--- a/fragments/kernel/cudalite.mk
+++ b/fragments/kernel/cudalite.mk
@@ -71,6 +71,8 @@ KERNEL_DEFAULT ?= kernel.cpp
 KERNEL_OBJECTS += $(KERNEL_SLIBRARIES:.s=.rvo)
 KERNEL_OBJECTS += $(KERNEL_CLIBRARIES:.c=.rvo)
 KERNEL_OBJECTS += $(KERNEL_CXXLIBRARIES:.cpp=.rvo)
+# If someone includes bsg_manycore's bsg_printf.rvo, replace it to trigger our specific rule
+KERNEL_OBJECTS := $(patsubst $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_printf.rvo,bsg_printf.rvo,$(KERNEL_OBJECTS))
 
 ################################################################################
 # Kernel Compilation Rules

--- a/fragments/kernel/link.mk
+++ b/fragments/kernel/link.mk
@@ -133,7 +133,9 @@ endif
 
 # BSG Manycore Library Variables
 BSG_MANYCORE_LIB_OBJECTS  += bsg_set_tile_x_y.rvo
-BSG_MANYCORE_LIB_OBJECTS  += bsg_printf.rvo
+# We don't include bsg_printf.rvo in all files so that we can reduce the
+# elf file sizes
+# BSG_MANYCORE_LIB_OBJECTS  += bsg_printf.rvo
 
 ################################################################################
 # Linker Flags


### PR DESCRIPTION
* This can be 50% of the kernel binary and contribute substantially to
  loading time