### PR TITLE
Single-Tile Memcopy

### DIFF
--- a/examples/tile_memcopy/Makefile
+++ b/examples/tile_memcopy/Makefile
@@ -1,0 +1,153 @@
+# Copyright (c) 2019, University of Washington All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# 
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+# 
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+# 
+# Neither the name of the copyright holder nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+################################################################################
+# Paths / Environment Configuration
+################################################################################
+_REPO_ROOT ?= $(shell git rev-parse --show-toplevel)
+CURRENT_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+-include $(_REPO_ROOT)/environment.mk
+
+################################################################################
+# Define BSG_MACHINE_PATH, the location of the Makefile.machine.include file
+# that defines the machine to compile and simulate on. Using BSG_F1_DIR (which
+# is set in environment.mk) uses the same machine as in bsg_replicant.
+################################################################################
+
+BSG_MACHINE_PATH=$(BSG_F1_DIR)
+
+################################################################################
+# Define the range of versions
+################################################################################
+# Kernel versions. See kernel/README.md for more information.  Version names do
+# not need to use v* and can be any string
+VERSIONS = v0 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10
+
+################################################################################
+# Define any sources that should be used compiled during kernel compilation,
+# including the source file with the kernel itself. kernel.riscv will
+# be the name of the compiled RISC-V Binary for the Manycore
+#
+# Use KERNEL_*LIBRARIES list sources that should be compiled and linked with all
+# kernel.cpp versions. However, if you have version-specific sources you must
+# come up with your own solution.
+# 
+# Use KERNEL_INCLUDES to specify the path to directories that contain headers.
+################################################################################
+
+# C Libraries
+KERNEL_CLIBRARIES   +=
+# C++ Libraries
+KERNEL_CXXLIBRARIES +=
+
+KERNEL_INCLUDES     += -I$(CURRENT_PATH)/kernel/include
+
+# Define the default kernel.cpp file. If KERNEL_DEFAULT is not defined it will
+# be set to kernel.cpp in the same directory as this Makefile.
+DEFAULT_VERSION     := v0
+KERNEL_DEFAULT      := kernel/$(DEFAULT_VERSION)/kernel.cpp
+
+################################################################################
+# Include the kernel build rules (This must be included after KERNEL_*LIBRARIES,
+# KERNEL_DEFAULT, KERNEL_INCLUDES, etc)
+################################################################################
+
+-include $(FRAGMENTS_PATH)/kernel/cudalite.mk
+
+################################################################################
+# END OF KERNEL-SPECIFIC RULES / START OF HOST-SPECIFIC RULES
+################################################################################
+
+
+################################################################################
+# Define the $(HOST_TARGET), the name of the host executable to generate. The
+# cosimulation host executable will be called
+# $(HOST_TARGET).cosim. HOST_*SOURCES list the host files that should be
+# compiled and linked into the executable.
+################################################################################
+
+HOST_TARGET         := tile_memcopy
+HOST_CSOURCES       := 
+HOST_CXXSOURCES     := $(HOST_TARGET).cpp
+HOST_INCLUDES       := -I$(CURRENT_PATH)
+
+################################################################################
+# Include the Cosimulation host build rules (This must be included after
+# HOST_*SOURCES, HOST_TARGET, HOST_INCLUDES, etc)
+################################################################################
+
+-include $(FRAGMENTS_PATH)/host/cosim.mk
+
+################################################################################
+# Define the clean rules. clean calls the makefile-specific cleans, whereas
+# users can add commands and dependencies to custom.clean.
+################################################################################
+version.clean:
+	rm -rf kernel/*/*{.csv,.log,.rvo,.riscv,.vpd,.key,.png,.dis}
+	rm -rf kernel/*/{stats,pc_stats}
+
+custom.clean: version.clean
+
+clean: cosim.clean analysis.clean cudalite.clean custom.clean
+
+################################################################################
+# Define overall-goals. The all rule runs all kernel versions, and the default
+# kernel.
+################################################################################
+
+_HELP_STRING := "Makefile Rules\n"
+
+_HELP_STRING += "    default: \n"
+_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "          analysis products\n"
+default: stats graphs pc_stats
+
+_HELP_STRING += "    analysis: \n"
+_HELP_STRING += "        - Launch indpendent cosimulation executions of each kernel version.\n"
+_HELP_STRING += "          When execution finishes, it generates the analysis products for \n"
+_HELP_STRING += "          each kernel in each respective kernel/version_name/ directory\n"
+analysis: $(foreach v,$(VERSIONS),kernel/$v/stats kernel/$v/graphs kernel/$v/pc_stats)
+
+_HELP_STRING += "    all: \n"
+_HELP_STRING += "        - Launch both the default and analysis target\n"
+all: analysis default
+
+.DEFAULT_GOAL = help
+_HELP_STRING += "    help: \n"
+_HELP_STRING += "        - Output a friendly help message.\n"
+help:
+	@echo -e $(HELP_STRING)
+
+# Always re-run, if asked.
+.PHONY: default analysis help
+
+# These last three lines ensure that _HELP_STRING is appended to the top of
+# whatever else comes before it.
+_HELP_STRING += "\n"
+_HELP_STRING += $(HELP_STRING)
+HELP_STRING := $(_HELP_STRING)

--- a/examples/tile_memcopy/README.md
+++ b/examples/tile_memcopy/README.md
@@ -1,0 +1,43 @@
+# Single-Tile Conv1D
+
+This example runs Conv1D (A (*) F = O) on a single tile. This test is
+intended to demonstrate different optimizations on a Manycore program.
+
+The kernel code is located in the subdirectories of [kernel](kernel). The actual
+matrix-multiplication code is in the header file
+[kernel/include/matrix_multiply.hpp](kernel/include/matrix_multiply.hpp). 
+
+# Makefile Targets
+
+For a list of all Makefile targets, run `make help`.
+
+## Versions
+
+There are several different versions of this kernel. Each is a subdirectory in
+the [kernel](kernel) directory.
+
+### Version 0
+
+This is a naive implementation on DMEM resident data.
+
+Optimizations: 
+  - None
+
+### Version 1
+
+This implementation uses a slightly cleverer method for indexing the
+input array that is amenable to unrolling. Instead of tracking an
+input index for data, it uses the filter index and the output
+index. (Though it has no effect)
+
+This may not work well with stepping.
+
+### Version 2
+
+This is implementation unrolls the outer loop to compute multiple
+output pixels concurrently. 
+
+### Version 3
+
+This version unrolls the outer loop, but also uses assembly to
+initialize the sum array.

--- a/examples/tile_memcopy/README.md
+++ b/examples/tile_memcopy/README.md
@@ -1,13 +1,21 @@
-# Single-Tile Conv1D
+# Single-Tile Memcopy
 
-This example runs Conv1D (A (*) F = O) on a single tile. This test is
-intended to demonstrate different optimizations on a Manycore program.
+This example memcpy on a single tile. This test is intended to demonstrate
+the effect of non-blocking loads on program performance.
 
-The kernel code is located in the subdirectories of [kernel](kernel). The actual
-matrix-multiplication code is in the header file
-[kernel/include/matrix_multiply.hpp](kernel/include/matrix_multiply.hpp). 
+The kernel code is located in the subdirectories of [kernel](kernel). 
 
-# Makefile Targets
+Each kernel copies a list of integers from INPUT into a temporary array on the
+tile (temp), adds one to each element, and then copies the result to
+OUTPUT. 
+
+Only INPUT->temp and temp->OUTPUT data transfer is profiled to understand the
+limitations of memory copy. INPUT/OUTPUT copy is run twice: First, to initialize
+the icache and victim cache, and again to understand remote-load
+performance. Therefore, Tags 0 (into tile) and 1 (out of tile) can be ignored,
+and tags 2 (into tile) and 3 (out of tile) profile data transfer performance.
+
+## Makefile Targets
 
 For a list of all Makefile targets, run `make help`.
 
@@ -16,28 +24,168 @@ For a list of all Makefile targets, run `make help`.
 There are several different versions of this kernel. Each is a subdirectory in
 the [kernel](kernel) directory.
 
+In general, tile-to-DRAM data transfer is not a limiting factor on
+performance. None of the kernels below stall on this data transfer path.
+
 ### Version 0
 
-This is a naive implementation on DMEM resident data.
+This version is the baseline. It uses memcpy from RISC-V
+[newlib](https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=newlib/libc/machine/riscv/memcpy.c). It
+issues 8 non-blocking remote loads `lw` before issuing `sw` instructions to
+store data in the destination buffer. (8 is probably a limitation of RV32E,
+which only has 15 GP registers).
 
-Optimizations: 
-  - None
+This version gets good performance. For an array of 256 4-byte elements and
+running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile transfer an IPC of
+.56, 562 stall cycles, and 1225 total cycles. The average element load-stall
+is 2.19 cycles.
 
 ### Version 1
 
-This implementation uses a slightly cleverer method for indexing the
-input array that is amenable to unrolling. Instead of tracking an
-input index for data, it uses the filter index and the output
-index. (Though it has no effect)
+This version demonstrates the pitfall of copying data using a rolled for-loop
+for data transfer. Each iteration of the loop loads data from DRAM/VCache and
+stores it to DMEM: 1 `lw`, followed by 1 `sw`. Because the `sw` instruction has
+a dependency on `lw`, each `sw` stalls for the entire request/response
+round-trip.
 
-This may not work well with stepping.
+This version gets poor performance. For an array of 256 4-byte elements and
+running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile transfer an IPC of
+.26, 3584 stall cycles, and 4887 total cycles. The average element load-stall
+is 14 cycles
 
 ### Version 2
 
-This is implementation unrolls the outer loop to compute multiple
-output pixels concurrently. 
+In theory, this version demonstrates the benefits of unrolling data copying by a
+factor of 2 using the `GCC unroll 2` pragma. In theory, each iteration of the
+loop loads two elements of data from DRAM/VCache and stores it to DMEM: 2 `lw`
+instructions, followed by 2 `sw` instructions. Because the `lw` instructions do
+not stall, some pipeline parallelism is present while the first `sw` instruction
+is stalled.
+
+However, this is not the case. The following is a snippet of the assembly: 
+
+```
+ 51c:	0007a683          	lw	x13,0(x15)
+ 520:	00878793          	addi	x15,x15,8
+ 524:	00870713          	addi	x14,x14,8
+ 528:	fed72c23          	sw	x13,-8(x14)
+ 52c:	ffc7a683          	lw	x13,-4(x15)
+ 530:	fed72e23          	sw	x13,-4(x14)
+```
+
+In this case, the `lw`/`sw` instructions are still interleaved. 
+
+However, this version gets better, but still poor, performance. For an array of 256
+4-byte elements and running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile
+transfer an IPC of .19, 3840 stall cycles, and 4766 total cycles. The average
+element load-stall is 11 cycles
 
 ### Version 3
 
-This version unrolls the outer loop, but also uses assembly to
-initialize the sum array.
+This version demonstrates the benefits of unrolling data copying by a factor of
+2 (manually). Each iteration of the loop loads two elements of data from
+DRAM/VCache and stores it to DMEM: 2 `lw` instructions, followed by 2 `sw`
+instructions. Because the `lw` instructions do not stall, some pipeline
+parallelism is present while the first `sw` instruction is stalled.
+
+This version gets better, but still poor, performance. For an array of 256
+4-byte elements and running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile
+transfer an IPC of .34, 1792 stall cycles, and 2711 total cycles. The average
+element load-stall is 7 cycles (half of v1).
+
+### Version 4
+
+This version is a failure. In this version, data is loaded into a temporary
+buffer before being stored in local DMEM. The data copy loop is unrolled by a
+factor of 4. In theory, this should allow 4 `lw` instructions to be issued
+concurrently before the first `sw` causes a stall. However, this is not the case
+because gcc reorders instructions and `lw`/`sw` instructions are interleaved.
+
+This version gets poor performance. For an array of 256 4-byte elements and
+running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile transfer an IPC of
+.17, 3904 stall cycles, and 4696 total cycles. The average element load-stall
+is 15 cycles (Worse than v1!).
+
+### Version 5
+
+This version uses the same approach as v4 (above) with substantially
+different results. Data is loaded into a temporary buffer before being stored in
+local DMEM. The data copy loop is unrolled by a factor of 8. However, in this
+version 8 `lw` instructions are issued concurrently before the first `sw` causes
+a stall. For some reason, GCC does not reorder instructions (who knows why) and
+performance is great.
+
+This version gets good performance, on par with v0. For an array of 256 4-byte
+elements and running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile
+transfer an IPC of .47, 736 stall cycles, and 1400 total cycles. The average
+element load-stall is 2.9 cycles (Worse than v0, but not by much!).
+
+### Version 6
+
+This version uses the same approach as v4 and v5 (above), again, with
+substantially different results than either of the previous versions. Data is
+loaded into a temporary buffer before being stored in local DMEM. The data copy
+loop is unrolled by a factor of 16. In this version 16 `lw` instructions are
+issued concurrently before the first `sw` causes a stall, however the `sw`
+instructions are not issued in the same order that the dependencies are produced
+(for instance the second `sw` instruction depends on the last `lw`
+instruction). For some reason, GCC does something different than v4 and v5 and
+performance is middling.
+
+This version gets poor performance, on par with v4. For an array of 256 4-byte
+elements and running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile
+transfer an IPC of .20, 2320 stall cycles, and 2920 total cycles. The average
+element load-stall is 9 cycles.
+
+### Version 7
+
+This version uses the same approach as v4-v6, except that data is loaded into a
+temporary buffer that is defined as a `float` array before being stored in local
+DMEM. This forces the compiler to use `flw` instructions and floating point `f`
+registers. The benefit of this is that there is no/little register pressure on
+fp registers since they are not used in the RISC-V ABI. 
+
+The data copy loop is unrolled by a factor of 16. In this version 16 `flw`
+instructions are issued concurrently before the first `sw` causes a
+stall. Unlike v6 and v4 (above) the `fsw` instructions appear in the correct
+order relative to their dependencies.
+
+This version gets fantastic performance, better than v0. For an array of 256
+4-byte elements and running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile
+transfer an IPC of .80, 144 stall cycles, and 744 total cycles. The average
+element load-stall is .56 cycles.
+
+### Version 8
+
+This version uses the same approach as v7, with substantially different
+results. 
+
+The data copy loop is unrolled by a factor of 32. In this version 32 `flw`
+instructions are issued concurrently before the first `sw` causes a stall. Like
+v4 and v6 above, the first `fsw` instruction depends on the last `flw`
+instruction. It is not clear why GCC is doing this.
+
+This version gets mediocre performance, on par with v3. For an array of 256
+4-byte elements and running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile
+transfer an IPC of .28, 1440 stall cycles, and 2008 total cycles. The average
+element load-stall is 5.6 cycles.
+
+### Version 9
+
+This version uses the same approach as v7 and v8, but uses assembly to specify
+the ordering of `flw` and `fsw` instructions. This proves optimal.
+
+The data copy loop is unrolled by a factor of 32. In this version 32 `flw`
+instructions are issued concurrently before the first `sw` causes a stall. As
+expected, the `fsw` instructions are ordered relative to their dependent `flw`
+instructions.
+
+This version gets the best performance. For an array of 256 4-byte elements and
+running on tile (0,0) of a 4x4 manycore DRAM/VCache -> Tile transfer an IPC of
+.9967, 0 stall cycles, and 600 total cycles. The average element load-stall is
+0 cycles.
+
+### Version 10
+
+This is identical to v9, except that it wraps standard memcopy for
+non-word-aligned transfers. This is the current, best definition of bsg_memcpy.

--- a/examples/tile_memcopy/kernel/v0/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v0/kernel.cpp
@@ -1,0 +1,52 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses memcpy as a baseline.
+//   * memcpy is unrolled by a factor of 8 internally (https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=blob;f=newlib/libc/machine/riscv/memcpy.c)
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                               const uint32_t i_nelements,
+                               int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+
+                for(int i = 0; i < 4; i+=2){
+                        bsg_cuda_print_stat_start(i);
+                        memcpy (temp, INPUT, sizeof(INPUT[0])*i_nelements);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j]++;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        memcpy (OUTPUT, temp, sizeof(OUTPUT[0])*i_nelements);
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v1/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v1/kernel.cpp
@@ -1,0 +1,58 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data.
+//   * No unrolling
+//   * Asm looks like lw/sw/lw/sw. 
+//     * lw/sw raw dependendencies cause a round-Trip latency on every element
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                               const uint32_t i_nelements,
+                               int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+
+                for(int i = 0; i < 4; i+=2){
+                        bsg_cuda_print_stat_start(i);
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] = INPUT[j];
+                        }
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v10/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v10/kernel.cpp
@@ -1,0 +1,95 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a for loop to copy data to rtemp, then write to DMEM
+//   * For loops use assembly
+//   * rtemp now declared as float
+//   * Unrolled by a factor of FACTOR (gcc pragma says 16, but array size/FACTOR dictates limit)
+//   * Asm looks like lw/*/sw* (32 loads in flight before stall),
+//   * sw dependencies ARE in same order as the lw producers. See:
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+#include <cstring>
+
+template <unsigned int FACTOR>
+void *__bsg_memcpy(void *dest,
+                   const void *src,
+                   const size_t n){
+                 
+        const float *psrc  asm ("x10") = reinterpret_cast<const float *>(src);
+        uint32_t src_nelements = n / sizeof(psrc[0]);
+        float *pdest asm ("x12") = reinterpret_cast<float *>(dest);
+
+        for(int j = 0; j < src_nelements; j+= FACTOR){
+                float rtemp[FACTOR];
+#pragma GCC unroll 32
+                for(int f = 0; f < FACTOR; f++){
+                        asm volatile ("flw %0,%1" : "=f" (rtemp[f]) : "m" (psrc[f]));
+                }
+
+                // Write
+#pragma GCC unroll 32
+                for(int f = 0; f < FACTOR; f++){
+                        asm volatile ("fsw %1,%0" : "=m" (pdest[f]) : "f" (rtemp[f]));
+                }
+                psrc += FACTOR;
+                pdest += FACTOR;
+        }
+        return dest;
+}
+
+__attribute__((noinline))
+void * bsg_memcpy(void *__restrict dst, const void *__restrict src, size_t n){
+        uintptr_t udst = reinterpret_cast<uintptr_t>(dst), usrc = reinterpret_cast<uintptr_t>(src);
+        static const unsigned int C_WORD_MASK = 0x3;
+        if ((n & C_WORD_MASK) | (udst & C_WORD_MASK) | (usrc & C_WORD_MASK)){
+                return memcpy(dst, src, n);
+        } else {
+                return __bsg_memcpy<32>(dst, src, n);
+        }
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcpy(temp, INPUT, i_nelements* sizeof(int));
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v2/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v2/kernel.cpp
@@ -1,0 +1,60 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data.
+//   * Unrolled by a factor of 2
+//   * Asm looks like lw/sw/lw/sw (instead of lw/lw/sw/sw goal)
+//     * lw/sw raw dependendencies cause a round-Trip latency on every element
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                               const uint32_t i_nelements,
+                               int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+
+                for(int i = 0; i < 4; i+=2){
+                        bsg_cuda_print_stat_start(i);
+                        // This fails miserably, since gcc does lw/sw/lw/sw instead of lw/lw/sw/sw
+#pragma GCC unroll 2
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] = INPUT[j];
+                        }
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v3/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v3/kernel.cpp
@@ -1,0 +1,58 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data.
+//   * Unrolled by a factor of 2 (manually)
+//   * Asm looks like lw/lw/sw/sw (2 loads in flight before stall)
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+#include <cstring>
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                               const uint32_t i_nelements,
+                               int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+
+                for(int i = 0; i < 4; i+=2){
+                        bsg_cuda_print_stat_start(i);
+                        for(int j = 0; j < i_nelements; j+= 2){
+                                temp[j] = INPUT[j];
+                                temp[j+1] = INPUT[j+1];
+                        }
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v4/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v4/kernel.cpp
@@ -1,0 +1,76 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data to rtemp, then write to DMEM
+//   * Unrolled by a factor of FACTOR (gcc pragma says 8, but array size dictates limit)
+//   * Asm looks like lw/lw/lw/lw/sw/sw/sw/sw (4 loads in flight before stall)
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+
+#define FACTOR 4
+void bsg_memcopy(const int *src,
+                 const uint32_t i_nelements,
+                 int *dest){
+
+        const int *psrc = &src[0];
+        int *pdest = &dest[0];
+        register int rtemp[FACTOR];
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+#pragma GCC unroll 8
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+                }
+
+#pragma GCC unroll 8
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+                }
+        }
+        return;
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcopy(INPUT, i_nelements, temp);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v5/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v5/kernel.cpp
@@ -1,0 +1,76 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data to rtemp, then write to DMEM
+//   * Unrolled by a factor of FACTOR (gcc pragma says 8, but array size dictates limit)
+//   * Asm looks like lw/lw/lw/lw/lw/lw/lw/lw/sw/sw/sw/sw/sw/sw/sw/sw (8 loads in flight before stall)
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+
+#define FACTOR 8
+void bsg_memcopy(const int *src,
+                 const uint32_t i_nelements,
+                 int *dest){
+
+        const int *psrc = &src[0];
+        int *pdest = &dest[0];
+        register int rtemp[FACTOR];
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+#pragma GCC unroll 8
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+                }
+
+#pragma GCC unroll 8
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+                }
+        }
+        return;
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcopy(INPUT, i_nelements, temp);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v6/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v6/kernel.cpp
@@ -1,0 +1,124 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data to rtemp, then write to DMEM
+//   * Unrolled by a factor of FACTOR (gcc pragma says 16, but array size/FACTOR dictates limit)
+//   * Asm looks like lw/*/sw* (16 loads in flight before stall),
+//   * HOWEVER sw dependencies are not the same order as the lw producers. See:
+
+
+/*
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+ 44c:	00452903          	lw	x18,4(x10)
+ 450:	00852483          	lw	x9,8(x10)
+ 454:	00c52403          	lw	x8,12(x10)
+ 458:	01052583          	lw	x11,16(x10)
+ 45c:	01452383          	lw	x7,20(x10)
+ 460:	01852283          	lw	x5,24(x10)
+ 464:	01c52f83          	lw	x31,28(x10)
+ 468:	02052f03          	lw	x30,32(x10)
+ 46c:	02452e83          	lw	x29,36(x10)
+ 470:	02852e03          	lw	x28,40(x10)
+ 474:	02c52303          	lw	x6,44(x10)
+ 478:	03052883          	lw	x17,48(x10)
+ 47c:	03452803          	lw	x16,52(x10)
+ 480:	03852683          	lw	x13,56(x10)
+ 484:	03c52703          	lw	x14,60(x10)
+                }
+
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+ 488:	00052a03          	lw	x20,0(x10)
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+ 48c:	01078793          	addi	x15,x15,16
+                        *pdest++ = rtemp[f];
+ 490:	01262223          	sw	x18,4(x12) // First lw
+ 494:	01462023          	sw	x20,0(x12) // Last lw !?
+ 498:	00962423          	sw	x9,8(x12)
+ 49c:	00862623          	sw	x8,12(x12)
+ 4a0:	00b62823          	sw	x11,16(x12)
+ 4a4:	00762a23          	sw	x7,20(x12)
+ 4a8:	00562c23          	sw	x5,24(x12)
+ 4ac:	01f62e23          	sw	x31,28(x12)
+ 4b0:	03e62023          	sw	x30,32(x12)
+ 4b4:	03d62223          	sw	x29,36(x12)
+ 4b8:	03c62423          	sw	x28,40(x12)
+ 4bc:	02662623          	sw	x6,44(x12)
+ 4c0:	03162823          	sw	x17,48(x12)
+ 4c4:	03062a23          	sw	x16,52(x12)
+ 4c8:	02d62c23          	sw	x13,56(x12)
+ 4cc:	02e62e23          	sw	x14,60(x12)
+*/
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+
+#define FACTOR 16
+void bsg_memcopy(const int *src,
+                 const uint32_t i_nelements,
+                 int *dest){
+
+        const int *psrc = &src[0];
+        int *pdest = &dest[0];
+        register int rtemp[FACTOR];
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+                }
+
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+                }
+        }
+        return;
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcopy(INPUT, i_nelements, temp);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v7/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v7/kernel.cpp
@@ -1,0 +1,130 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data to rtemp, then write to DMEM
+//   * rtemp now declared as float (Perhaps integer register pressure is causing issues??)
+//   * Unrolled by a factor of FACTOR (gcc pragma says 16, but array size/FACTOR dictates limit)
+//   * Asm looks like lw/*/sw* (16 loads in flight before stall),
+//   * sw dependencies ARE in same order as the lw producers. See:
+
+/*
+        const float *psrc = reinterpret_cast<const float *>(&src[0]);
+        float *pdest = reinterpret_cast<float *>(&dest[0]);
+        register float rtemp[FACTOR];
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+ 428:	08058c63          	beqz	x11,4c0 <_Z11bsg_memcopyPKimPi+0x98>
+ 42c:	00000793          	li	x15,0
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+ 430:	00052887          	flw	f17,0(x10)
+ 434:	00452807          	flw	f16,4(x10)
+ 438:	00852387          	flw	f7,8(x10)
+ 43c:	00c52307          	flw	f6,12(x10)
+ 440:	01052287          	flw	f5,16(x10)
+ 444:	01452207          	flw	f4,20(x10)
+ 448:	01852187          	flw	f3,24(x10)
+ 44c:	01c52107          	flw	f2,28(x10)
+ 450:	02052087          	flw	f1,32(x10)
+ 454:	02452007          	flw	f0,36(x10)
+ 458:	02852507          	flw	f10,40(x10)
+ 45c:	02c52587          	flw	f11,44(x10)
+ 460:	03052607          	flw	f12,48(x10)
+ 464:	03452687          	flw	f13,52(x10)
+ 468:	03852707          	flw	f14,56(x10)
+ 46c:	03c52787          	flw	f15,60(x10)
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+ 470:	01078793          	addi	x15,x15,16
+                }
+
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+ 474:	01162027          	fsw	f17,0(x12)
+ 478:	01062227          	fsw	f16,4(x12)
+ 47c:	00762427          	fsw	f7,8(x12)
+ 480:	00662627          	fsw	f6,12(x12)
+ 484:	00562827          	fsw	f5,16(x12)
+ 488:	00462a27          	fsw	f4,20(x12)
+ 48c:	00362c27          	fsw	f3,24(x12)
+ 490:	00262e27          	fsw	f2,28(x12)
+ 494:	02162027          	fsw	f1,32(x12)
+ 498:	02062227          	fsw	f0,36(x12)
+ 49c:	02a62427          	fsw	f10,40(x12)
+ 4a0:	02b62627          	fsw	f11,44(x12)
+ 4a4:	02c62827          	fsw	f12,48(x12)
+ 4a8:	02d62a27          	fsw	f13,52(x12)
+ 4ac:	02e62c27          	fsw	f14,56(x12)
+ 4b0:	02f62e27          	fsw	f15,60(x12)
+*/
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+
+#define FACTOR 16
+void bsg_memcopy(const int *src,
+                 const uint32_t i_nelements,
+                 int *dest){
+
+        const float *psrc = reinterpret_cast<const float *>(&src[0]);
+        float *pdest = reinterpret_cast<float *>(&dest[0]);
+        register float rtemp[FACTOR];
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+                }
+
+#pragma GCC unroll 16
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+                }
+        }
+        return;
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcopy(INPUT, i_nelements, temp);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v8/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v8/kernel.cpp
@@ -1,0 +1,159 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a simple for loop to copy data to rtemp, then write to DMEM
+//   * rtemp now declared as float
+//   * Unrolled by a factor of FACTOR (gcc pragma says 16, but array size/FACTOR dictates limit)
+//   * Asm looks like lw/*/sw* (32 loads in flight before stall),
+//   * sw dependencies ARE NOT in same order as the lw producers. See:
+
+// * Not optimal, since first fsw depends on last flw.
+
+/*
+#pragma GCC unroll 32
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+ 464:	00452d07          	flw	f26,4(x10)
+ 468:	00852c87          	flw	f25,8(x10)
+ 46c:	00c52c07          	flw	f24,12(x10)
+ 470:	01052b87          	flw	f23,16(x10)
+ 474:	01452b07          	flw	f22,20(x10)
+ 478:	01852a87          	flw	f21,24(x10)
+ 47c:	01c52a07          	flw	f20,28(x10)
+ 480:	02052987          	flw	f19,32(x10)
+ 484:	02452907          	flw	f18,36(x10)
+ 488:	02852487          	flw	f9,40(x10)
+ 48c:	02c52407          	flw	f8,44(x10)
+ 490:	03052f87          	flw	f31,48(x10)
+ 494:	03452f07          	flw	f30,52(x10)
+ 498:	03852e87          	flw	f29,56(x10)
+ 49c:	03c52e07          	flw	f28,60(x10)
+ 4a0:	04052887          	flw	f17,64(x10)
+ 4a4:	04452807          	flw	f16,68(x10)
+ 4a8:	04852387          	flw	f7,72(x10)
+ 4ac:	04c52307          	flw	f6,76(x10)
+ 4b0:	05052287          	flw	f5,80(x10)
+ 4b4:	05452207          	flw	f4,84(x10)
+ 4b8:	05852187          	flw	f3,88(x10)
+ 4bc:	05c52107          	flw	f2,92(x10)
+ 4c0:	06052087          	flw	f1,96(x10)
+ 4c4:	06452007          	flw	f0,100(x10)
+ 4c8:	06852507          	flw	f10,104(x10)
+ 4cc:	06c52587          	flw	f11,108(x10)
+ 4d0:	07052607          	flw	f12,112(x10)
+ 4d4:	07452687          	flw	f13,116(x10)
+ 4d8:	07852707          	flw	f14,120(x10)
+ 4dc:	07c52787          	flw	f15,124(x10)
+                }
+
+#pragma GCC unroll 32
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+ 4e0:	00052d87          	flw	f27,0(x10)    // Last flw
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+ 4e4:	02078793          	addi	x15,x15,32
+ 4e8:	08060613          	addi	x12,x12,128
+                        *pdest++ = rtemp[f];
+ 4ec:	f9b62027          	fsw	f27,-128(x12) // First fsw depends on f27!
+ 4f0:	f9a62227          	fsw	f26,-124(x12)
+ 4f4:	f9962427          	fsw	f25,-120(x12)
+ 4f8:	f9862627          	fsw	f24,-116(x12)
+ 4fc:	f9762827          	fsw	f23,-112(x12)
+ 500:	f9662a27          	fsw	f22,-108(x12)
+ 504:	f9562c27          	fsw	f21,-104(x12)
+ 508:	f9462e27          	fsw	f20,-100(x12)
+ 50c:	fb362027          	fsw	f19,-96(x12)
+ 510:	fb262227          	fsw	f18,-92(x12)
+ 514:	fa962427          	fsw	f9,-88(x12)
+ 518:	fa862627          	fsw	f8,-84(x12)
+ 51c:	fbf62827          	fsw	f31,-80(x12)
+ 520:	fbe62a27          	fsw	f30,-76(x12)
+ 524:	fbd62c27          	fsw	f29,-72(x12)
+ 528:	fbc62e27          	fsw	f28,-68(x12)
+ 52c:	fd162027          	fsw	f17,-64(x12)
+ 530:	fd062227          	fsw	f16,-60(x12)
+ 534:	fc762427          	fsw	f7,-56(x12)
+ 538:	fc662627          	fsw	f6,-52(x12)
+ 53c:	fc562827          	fsw	f5,-48(x12)
+ 540:	fc462a27          	fsw	f4,-44(x12)
+ 544:	fc362c27          	fsw	f3,-40(x12)
+ 548:	fc262e27          	fsw	f2,-36(x12)
+ 54c:	fe162027          	fsw	f1,-32(x12)
+ 550:	fe062227          	fsw	f0,-28(x12)
+ 554:	fea62427          	fsw	f10,-24(x12)
+ 558:	feb62627          	fsw	f11,-20(x12)
+ 55c:	fec62827          	fsw	f12,-16(x12)
+ 560:	fed62a27          	fsw	f13,-12(x12)
+ 564:	fee62c27          	fsw	f14,-8(x12)
+ 568:	fef62e27          	fsw	f15,-4(x12)
+*/
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+
+#define FACTOR 32
+void bsg_memcopy(const int *src,
+                 const uint32_t i_nelements,
+                 int *dest){
+
+        const float *psrc = reinterpret_cast<const float *>(&src[0]);
+        float *pdest = reinterpret_cast<float *>(&dest[0]);
+        register float rtemp[FACTOR];
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+#pragma GCC unroll 32
+                for (int f = 0 ; f < FACTOR; ++f){
+                        rtemp[f] = *psrc++;
+                }
+
+#pragma GCC unroll 32
+                for (int f = 0 ; f < FACTOR; ++f){
+                        *pdest++ = rtemp[f];
+                }
+        }
+        return;
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcopy(INPUT, i_nelements, temp);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/kernel/v9/kernel.cpp
+++ b/examples/tile_memcopy/kernel/v9/kernel.cpp
@@ -1,0 +1,152 @@
+// Copies a list of integers from INPUT into a tile, adds one to each element,
+// and then copies the result to OUTPUT. Only INPUT/OUTPUT data transfer is
+// profiled to understand the limitations of memory copy. INPUT/OUTPUT copy is
+// run twice to initialize the icache, which also brings the data into the
+// victim cache. Therefore, Tags 0 (into tile) and 1 (out of tile) can be
+// ignored, and tags 2 (into tile) and 3 (out of tile) profile data transfer
+// performance.
+
+// * Kernel code is small enough to be loaded into icache. (don't rely on this)
+// * Uses a for loop to copy data to rtemp, then write to DMEM
+//   * For loops use assembly
+//   * rtemp now declared as float
+//   * Unrolled by a factor of FACTOR (gcc pragma says 16, but array size/FACTOR dictates limit)
+//   * Asm looks like lw/*/sw* (32 loads in flight before stall),
+//   * sw dependencies ARE in same order as the lw producers. See:
+
+/*
+                        asm volatile ("flw %0,%1" : "=f" (rtemp[f]) : "m" (psrc[f]));
+ 7c0:	00052d87          	flw	f27,0(x10)
+ 7c4:	00452d07          	flw	f26,4(x10)
+ 7c8:	00852c87          	flw	f25,8(x10)
+ 7cc:	00c52c07          	flw	f24,12(x10)
+ 7d0:	01052b87          	flw	f23,16(x10)
+ 7d4:	01452b07          	flw	f22,20(x10)
+ 7d8:	01852a87          	flw	f21,24(x10)
+ 7dc:	01c52a07          	flw	f20,28(x10)
+ 7e0:	02052987          	flw	f19,32(x10)
+ 7e4:	02452907          	flw	f18,36(x10)
+ 7e8:	02852487          	flw	f9,40(x10)
+ 7ec:	02c52407          	flw	f8,44(x10)
+ 7f0:	03052f87          	flw	f31,48(x10)
+ 7f4:	03452f07          	flw	f30,52(x10)
+ 7f8:	03852e87          	flw	f29,56(x10)
+ 7fc:	03c52e07          	flw	f28,60(x10)
+ 800:	04052887          	flw	f17,64(x10)
+ 804:	04452807          	flw	f16,68(x10)
+ 808:	04852387          	flw	f7,72(x10)
+ 80c:	04c52307          	flw	f6,76(x10)
+ 810:	05052287          	flw	f5,80(x10)
+ 814:	05452207          	flw	f4,84(x10)
+ 818:	05852187          	flw	f3,88(x10)
+ 81c:	05c52107          	flw	f2,92(x10)
+ 820:	06052087          	flw	f1,96(x10)
+ 824:	06452007          	flw	f0,100(x10)
+ 828:	06852507          	flw	f10,104(x10)
+ 82c:	06c52587          	flw	f11,108(x10)
+ 830:	07052607          	flw	f12,112(x10)
+ 834:	07452687          	flw	f13,116(x10)
+ 838:	07852707          	flw	f14,120(x10)
+ 83c:	07c52787          	flw	f15,124(x10)
+                        asm volatile ("fsw %1,%0" : "=m" (pdest[f]) : "f" (rtemp[f]));
+ 840:	01b62027          	fsw	f27,0(x12)
+ 844:	01a62227          	fsw	f26,4(x12)
+ 848:	01962427          	fsw	f25,8(x12)
+ 84c:	01862627          	fsw	f24,12(x12)
+ 850:	01762827          	fsw	f23,16(x12)
+ 854:	01662a27          	fsw	f22,20(x12)
+ 858:	01562c27          	fsw	f21,24(x12)
+ 85c:	01462e27          	fsw	f20,28(x12)
+ 860:	03362027          	fsw	f19,32(x12)
+ 864:	03262227          	fsw	f18,36(x12)
+ 868:	02962427          	fsw	f9,40(x12)
+ 86c:	02862627          	fsw	f8,44(x12)
+ 870:	03f62827          	fsw	f31,48(x12)
+ 874:	03e62a27          	fsw	f30,52(x12)
+ 878:	03d62c27          	fsw	f29,56(x12)
+ 87c:	03c62e27          	fsw	f28,60(x12)
+ 880:	05162027          	fsw	f17,64(x12)
+ 884:	05062227          	fsw	f16,68(x12)
+ 888:	04762427          	fsw	f7,72(x12)
+ 88c:	04662627          	fsw	f6,76(x12)
+ 890:	04562827          	fsw	f5,80(x12)
+ 894:	04462a27          	fsw	f4,84(x12)
+ 898:	04362c27          	fsw	f3,88(x12)
+ 89c:	04262e27          	fsw	f2,92(x12)
+ 8a0:	06162027          	fsw	f1,96(x12)
+ 8a4:	06062227          	fsw	f0,100(x12)
+ 8a8:	06a62427          	fsw	f10,104(x12)
+ 8ac:	06b62627          	fsw	f11,108(x12)
+ 8b0:	06c62827          	fsw	f12,112(x12)
+ 8b4:	06d62a27          	fsw	f13,116(x12)
+ 8b8:	06e62c27          	fsw	f14,120(x12)
+ 8bc:	06f62e27          	fsw	f15,124(x12)
+*/
+
+// BSG_TILE_GROUP_X_DIM and BSG_TILE_GROUP_Y_DIM must be defined
+// before bsg_manycore.h and bsg_tile_group_barrier.h are
+// included. bsg_tiles_X and bsg_tiles_Y must also be defined for
+// legacy reasons, but they are deprecated.
+#define BSG_TILE_GROUP_X_DIM 1
+#define BSG_TILE_GROUP_Y_DIM 1
+#define bsg_tiles_X BSG_TILE_GROUP_X_DIM
+#define bsg_tiles_Y BSG_TILE_GROUP_Y_DIM
+#include <bsg_manycore.h>
+#include <bsg_tile_group_barrier.h>
+#include <cstdint>
+
+template <unsigned int FACTOR>
+__attribute__((noinline))
+void bsg_memcopy(const int *src,
+                 const uint32_t i_nelements,
+                 int *dest){
+
+        const float *psrc  asm ("x10") = reinterpret_cast<const float *>(&src[0]);
+        float *pdest asm ("x12") = reinterpret_cast<float *>(&dest[0]);
+
+        for(int j = 0; j < i_nelements; j+= FACTOR){
+                float rtemp[FACTOR];
+#pragma GCC unroll 32
+                for(int f = 0; f < FACTOR; f++){
+                        asm volatile ("flw %0,%1" : "=f" (rtemp[f]) : "m" (psrc[f]));
+                }
+
+                // Write
+#pragma GCC unroll 32
+                for(int f = 0; f < FACTOR; f++){
+                        asm volatile ("fsw %1,%0" : "=m" (pdest[f]) : "f" (rtemp[f]));
+                }
+                psrc += FACTOR;
+                pdest += FACTOR;
+        }
+        return;
+}
+
+extern "C" {
+        __attribute__((noinline))
+        int kernel_tile_memcopy(const int *INPUT,
+                                const uint32_t i_nelements,
+                                int *OUTPUT)
+        {
+                int rc;
+
+                int temp[i_nelements];
+                for(int i = 0; i < 4; i += 2){
+                        bsg_cuda_print_stat_start(i);
+                        bsg_memcopy<32>(INPUT, i_nelements, temp);
+                        bsg_cuda_print_stat_end(i);
+
+                        for(int j = 0; j < i_nelements; ++j){
+                                temp[j] += 1;
+                        }
+                                
+                        bsg_cuda_print_stat_start(i + 1);
+                        for(int j = 0; j < i_nelements; ++j){
+                                OUTPUT[j] = temp[j];
+                        }
+                        bsg_cuda_print_stat_end(i + 1);
+                }
+
+                return rc;
+        }
+}

--- a/examples/tile_memcopy/tile_memcopy.cpp
+++ b/examples/tile_memcopy/tile_memcopy.cpp
@@ -1,0 +1,207 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "tile_memcopy.hpp"
+#include <iostream>
+
+#define C_LENGTH 256
+
+// Print matrix A (M x N). This works well for small matricies.
+template <typename T>
+void matrix_print(T *A, uint64_t M, uint64_t N) {
+        T sum = 0;
+        for (uint64_t y = 0; y < M; y ++) {
+                for (uint64_t x = 0; x < N; x ++) {
+                        std::cout << A[y * N + x] << " ";
+                }
+                std::cout << '\n';
+
+        }
+}
+
+// Compute the sum of squared error between matricies A and B (M x N)
+template <typename T>
+double matrix_sse (const T *A, const T *B, uint64_t M, uint64_t N) {
+        double sum = 0;
+        for (uint64_t y = 0; y < M; y ++) {
+                for (uint64_t x = 0; x < N; x ++) {
+                        T diff = A[y * N + x] - B[y * N + x];
+                        if(std::isnan(diff)){
+                                return diff;
+                        }
+                        sum += diff * diff;
+                }
+        }
+        return sum;
+}
+
+int kernel_memcopy(int argc, char **argv)
+{       
+        bsg_pr_test_info("Running CUDA Memcopy Kernel on a 1x1 tile group.\n\n");
+        char *elf, *test_name;
+        struct arguments_path args = { NULL, NULL };
+        argp_parse(&argp_path, argc, argv, 0, 0, &args);
+        elf = args.path;
+        test_name = args.name;
+
+        int rc;
+        hb_mc_device_t manycore, *mc = &manycore;
+        rc = hb_mc_device_init(mc, test_name, 0);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to initialize device.\n");
+                return rc;
+        }
+
+        rc = hb_mc_device_program_init(mc, elf, "default_allocator", 0);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to initialize the program.\n");
+                return rc;
+        }
+
+        // Initialize the random number generators
+        std::numeric_limits<int32_t> lim_int32; // Used to get INT_MIN and INT_MAX in C++
+        std::default_random_engine generator;
+        generator.seed(42);
+        std::uniform_int_distribution<int> data_distribution(lim_int32.min(),lim_int32.max());
+
+        // N: Number of elements in the 1-D input vector
+        uint32_t N = C_LENGTH;
+        
+        int A[N];
+        int B[N], B_result[N];
+
+        eva_t A_device, B_device;
+        rc = hb_mc_device_malloc(mc, sizeof(A), &A_device);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to allocate A on the manycore.\n");
+                return rc;
+        }
+        
+        rc = hb_mc_device_malloc(mc, sizeof(B), &B_device);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to allocate B on the manycore.\n");
+                return rc;
+        }
+
+        for(int i = 0; i < sizeof(A) / sizeof(A[0]); i++)
+        {
+                A[i] = data_distribution(generator);
+                B[i] = A[i] + 1;
+        }
+        
+        rc = hb_mc_device_memcpy(mc,
+                                 (void *) ((intptr_t) A_device),
+                                 (void *) &A[0],
+                                 sizeof(A), HB_MC_MEMCPY_TO_DEVICE);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to copy A to the manycore.\n");
+                return rc;
+        }
+        
+
+        hb_mc_dimension_t tilegroup_dim = { .x = 1, .y = 1 };
+        hb_mc_dimension_t grid_dim = { .x = 1, .y = 1 };
+
+        uint32_t cuda_argv[] = { A_device, N, B_device};
+        size_t cuda_argc = sizeof(cuda_argv) / sizeof(cuda_argv[0]);
+        rc = hb_mc_kernel_enqueue(mc, grid_dim, tilegroup_dim, "kernel_tile_memcopy", cuda_argc, cuda_argv);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to initialize grid.\n");
+                return rc;
+        }
+
+        rc = hb_mc_device_tile_groups_execute(mc);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to execute tilegroups.\n");
+                return rc;
+        }
+
+        rc = hb_mc_device_memcpy(mc, (void *) B_result,
+                                 (void *) ((intptr_t) B_device),
+                                 sizeof(B), HB_MC_MEMCPY_TO_HOST);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to copy result to host.\n");
+                return rc;
+        }
+
+        rc = hb_mc_device_finish(mc);
+        if(rc != HB_MC_SUCCESS)
+        {
+                bsg_pr_test_err("Failed to deinitialize the manycore.\n");
+                return rc;
+        }
+
+        float sse;
+        sse = matrix_sse(B, B_result, 1, N);
+
+        if(std::isnan(sse) || sse > .01)
+        {
+                bsg_pr_test_err(BSG_RED("Result mismatch! SSE: %f\n"), sse);
+                return HB_MC_FAIL;
+        }
+        bsg_pr_test_info(BSG_GREEN("Result match! (SSE: %f)\n"), sse);
+        return HB_MC_SUCCESS;
+}
+
+#ifdef COSIM
+void cosim_main(uint32_t *exit_code, char *args)
+{
+        // We aren't passed command line arguments directly so we parse them
+        // from *args. args is a string from VCS - to pass a string of arguments
+        // to args, pass c_args to VCS as follows: +c_args="<space separated
+        // list of args>"
+        int argc = get_argc(args);
+        char *argv[argc];
+        get_argv(args, argc, argv);
+
+#ifdef VCS
+        svScope scope;
+        scope = svGetScopeFromName("tb");
+        svSetScope(scope);
+#endif
+        int rc = kernel_memcopy(argc, argv);
+        *exit_code = rc;
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return;
+}
+#else
+int main(int argc, char **argv)
+{
+        int rc = kernel_memcopy(argc, argv);
+        bsg_pr_test_pass_fail(rc == HB_MC_SUCCESS);
+        return rc;
+}
+#endif
+

--- a/examples/tile_memcopy/tile_memcopy.hpp
+++ b/examples/tile_memcopy/tile_memcopy.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef __CONV1D_HPP
+#define __CONV1D_HPP
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <cstring>
+#include <ctime>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
+#include <random>
+#include <limits>
+#include <bsg_manycore_errno.h>
+#include <bsg_manycore_cuda.h>
+
+#include "../common.h"
+
+#endif


### PR DESCRIPTION
This is a benchmark of single-tile memory copy. A single tile (0,0) loads data from DRAM. 

There are 11 versions (!) of this code. v0 uses standard c/c++ memcopy from newlib, which is surprisingly good. The subsequent versions try to improve this with varying results (awful to excellent).

This ended up being an exercise in getting GCC to "just do the right thing". See the README for more information.