### PR TITLE
Adds unroll-loops flag.

### DIFF
--- a/fragments/kernel/compile.mk
+++ b/fragments/kernel/compile.mk
@@ -62,6 +62,7 @@ RISCV_CCPPFLAGS += -static
 RISCV_CCPPFLAGS += -ffast-math
 RISCV_CCPPFLAGS += -fno-common
 RISCV_CCPPFLAGS += -ffp-contract=off
+RISCV_CCPPFLAGS += -funroll-loops
 
 RISCV_CFLAGS   += -std=gnu99 $(RISCV_CCPPFLAGS)
 RISCV_CXXFLAGS += -std=c++11 $(RISCV_CCPPFLAGS)

--- a/fragments/kernel/compile.mk
+++ b/fragments/kernel/compile.mk
@@ -62,7 +62,7 @@ RISCV_CCPPFLAGS += -static
 RISCV_CCPPFLAGS += -ffast-math
 RISCV_CCPPFLAGS += -fno-common
 RISCV_CCPPFLAGS += -ffp-contract=off
-RISCV_CCPPFLAGS += -funroll-loops
+RISCV_CCPPFLAGS += -frerun-cse-after-loop -fweb -frename-registers
 
 RISCV_CFLAGS   += -std=gnu99 $(RISCV_CCPPFLAGS)
 RISCV_CXXFLAGS += -std=c++11 $(RISCV_CCPPFLAGS)


### PR DESCRIPTION
The behavior of `#pragma GCC unroll X` is depends heavily on this flag being set.

The pass in GCC that responds to this pragma introduces anti-dependencies by reusing the same virtual register in each copy of the loop body. It relies on a later pass, which is not enabled by default, to go through and rename these virtual registers to remove those anti-dependencies. Without that pass, the effect cascades all the way through register allocation and the final instruction scheduling.

While `-frename-registers` fixes this but we have noticed that it results in slightly worse code than `-funroll-loops`. This likely due to other missing passes on which loop unrolling relies. 

Example scalar-vector-add C code:
```C
int svadd(int * __restrict O,
          int * __restrict I,
          int b,
          int N)
{
    #pragma GCC unroll 2
    for (int i = 0; i < N; ++i) {
        O[i] = I[i] + b;
    }
    return 0;
}
```

GCC output assembly without `-funroll-loops`:
```asm
svadd(int*, int*, int, int):
        blez    a3,.L2
        addiw   a3,a3,-1
        slli    a3,a3,32
        srli    a3,a3,30
        addi    a6,a1,4
        add     a3,a3,a6
        sub     a5,a3,a1
        addi    a5,a5,-4
        srli    a5,a5,2
        andi    a5,a5,1
        bnez    a5,.L3
        lw      a4,0(a1)
        addi    a0,a0,4
        mv      a1,a6
        addw    a5,a4,a2
        sw      a5,-4(a0)
        beq     a6,a3,.L2
.L3: 
// the unrolled loop body
        lw      a4,0(a1)
        addi    a1,a1,8
        addi    a0,a0,8
        addw    a5,a4,a2
// notice that there is a WAR dependence here on a4
// this forces the above addw to be scheduled before this load
        lw      a4,-4(a1)
        sw      a5,-8(a0)
        addw    a5,a4,a2
        sw      a5,-4(a0)
        bne     a1,a3,.L3
.L2:
        li      a0,0
        ret
```

GCC output with `-funroll-loops`:
```asm
svadd(int*, int*, int, int):
        blez    a3,.L2
        addiw   a3,a3,-1
        slli    t0,a3,32
        srli    t1,t0,30
        addi    a4,a1,4
        add     t2,t1,a4
        sub     a5,t2,a1
        addi    a6,a5,-4
        srli    a7,a6,2
        andi    t3,a7,1
        bnez    t3,.L3
        lw      t4,0(a1)
        addi    a0,a0,4
        mv      a1,a4
        addw    t5,t4,a2
        sw      t5,-4(a0)
        beq     a4,t2,.L2
.L3:
// here the WAR dependence has been removed and we can schedule the second load
// before the addw
        lw      t6,0(a1)
        lw      a3,4(a1)
        addi    a1,a1,8
        addw    t0,t6,a2
        addw    t1,a3,a2
        sw      t0,0(a0)
        sw      t1,4(a0)
        addi    a0,a0,8
        bne     a1,t2,.L3
.L2:
        li      a0,0
        ret
```