### PR TITLE
Clang compile

### DIFF
--- a/examples/vector_add/Makefile
+++ b/examples/vector_add/Makefile
@@ -108,7 +108,7 @@ HOST_INCLUDES       := -I$(CURRENT_PATH)
 # users can add commands and dependencies to custom.clean.
 ################################################################################
 version.clean:
-	rm -rf kernel/*/*{.csv,.log,.rvo,.riscv,.vpd,.key,.png,.dis}
+	rm -rf kernel/*/*{.csv,.log,.rvo,.riscv,.vpd,.key,.png,.dis,.ll,.ll.s}
 	rm -rf kernel/*/{stats,pc_stats}
 
 custom.clean: version.clean

--- a/fragments/kernel/clang/compile.mk
+++ b/fragments/kernel/clang/compile.mk
@@ -10,18 +10,15 @@ LLVM_CLANGXX     ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
 LLVM_LIB         ?= $(LLVM_DIR)/lib
-LLVM_INCL        ?= $(LLVM_DIR)/include/c++/v1
 RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
 
-CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
+CLANG_TARGET_OPTS ?= --target=riscv32 -mabi=$(ABI)
 LLC_TARGET_OPTS ?= -march=riscv32 -mcpu=$(CPU_OP)
 
-#some flags are not supported by clang, so redefine the cxx flags here
-CLANG_RISCV_CFLAGS := $(OPT_LEVEL) $(DEBUG_FLAGS) -static -ffast-math -fno-common -ffp-contract=off 
 CLANG_RISCV_CXXFLAGS := --sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
     -I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0 \
 		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0/riscv32-unknown-elf-dramfs  
-CLANG_RISCV_CXXFLAGS += -v -std=c++11 -stdlib=libstdc++ -O2  $(DEBUG_FLAGS) -static -ffast-math -fno-common -ffp-contract=off 
+CLANG_RISCV_CXXFLAGS += $(RISCV_CXXFLAGS)
 
 $(LLVM_DIR):
 	$(error $(shell echo -e "$(RED)BSG MAKE ERROR: LLVM Has not been built! Please run the Setup instructions in README.md $(_REPO_ROOT)$(NC)")
@@ -29,7 +26,7 @@ $(LLVM_DIR):
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
 %.ll: %.c $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(CLANG_RISCV_CFLAGS) $(RISCV_DEFINES) $(RISCV_INCLUDES) -emit-llvm -c -S $< -o $@ |& tee $*.clang.log
+	$(LLVM_CLANG) $(CLANG_TARGET_OPTS) $(RISCV_CFLAGS) $(RISCV_DEFINES) $(RISCV_INCLUDES) -emit-llvm -c -S $< -o $@ |& tee $*.clang.log
 
 # do the same for C++ sources
 %.ll: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)

--- a/fragments/kernel/clang/compile.mk
+++ b/fragments/kernel/clang/compile.mk
@@ -1,32 +1,47 @@
+ARCH_OP=rv32imaf
+ABI=ilp32f
+CPU_OP = hb-rv32
+
+%.rvo: RISCV_INCLUDES += $(KERNEL_INCLUDES)
+
 LLVM_DIR         ?= $(BSG_MANYCORE_DIR)/software/riscv-tools/llvm/llvm-install
 LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
+LLVM_CLANGXX     ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
-PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
-PASS_LIB         ?= build/manycore/libManycorePass.so
+LLVM_LIB         ?= $(LLVM_DIR)/lib
+LLVM_INCL        ?= $(LLVM_DIR)/include/c++/v1
 RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
+
+CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
+LLC_TARGET_OPTS ?= -march=riscv32 -mcpu=$(CPU_OP)
+
+#some flags are not supported by clang, so redefine the cxx flags here
+CLANG_RISCV_CFLAGS := $(OPT_LEVEL) $(DEBUG_FLAGS) -static -ffast-math -fno-common -ffp-contract=off 
+CLANG_RISCV_CXXFLAGS := --sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
+    -I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0 \
+		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0/riscv32-unknown-elf-dramfs  
+CLANG_RISCV_CXXFLAGS += -v -std=c++11 -stdlib=libstdc++ -O2  $(DEBUG_FLAGS) -static -ffast-math -fno-common -ffp-contract=off 
 
 $(LLVM_DIR):
 	$(error $(shell echo -e "$(RED)BSG MAKE ERROR: LLVM Has not been built! Please run the Setup instructions in README.md $(_REPO_ROOT)$(NC)")
 
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
-%.bc: %.c $(PASS_LIB) $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(RISCV_CFLAGS) $(RISCV_DEFINES) $(RISCV_INCLUDES) -c -emit-llvm $< -o $@ |& tee $*.clang.log
+%.ll: %.c $(LLVM_DIR) $(RUNTIME_FNS)
+	$(LLVM_CLANG) $(CLANG_RISCV_CFLAGS) $(RISCV_DEFINES) $(RISCV_INCLUDES) -emit-llvm -c -S $< -o $@ |& tee $*.clang.log
 
 # do the same for C++ sources
-%.bc: %.cpp $(PASS_LIB) $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(RISCV_CFLAGS) $(RISCV_DEFINES) $(RISCV_INCLUDES)_defs) -c -emit-llvm  $< -o $@ |& tee $*.clang.log
+%.ll: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)
+	$(LLVM_CLANGXX) $(CLANG_TARGET_OPTS) $(CLANG_RISCV_CXXFLAGS) $(RISCV_DEFINES) $(RISCV_INCLUDES) -c -emit-llvm  $< -o $@ |& tee $*.clang.log
 
-%.bc.pass: %.bc
-	$(LLVM_OPT) -load $(PASS_LIB) -manycore $(OPT_LEVEL) $< -o $@
+%.ll.s: %.ll
+	$(LLVM_LLC) $(LLC_TARGET_OPTS) $< -o $@
 
-%.bc.s: %.bc.pass
-	$(LLVM_LLC) $< -o $@
-
-%.rvo: %.bc.s
+%.rvo: %.ll.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@
 
-$(PASS_LIB): $(PASS_DIR)/manycore/Manycore.cpp $(LLVM_DIR)
-	mkdir -p build
-	cd build && LLVM_DIR=$(LLVM_DIR) cmake3 $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make
+.PRECIOUS: %.ll %.ll.s
+
+kernel.compile.clean:
+	rm -rf *.rvo *.clang.log *.rva *.a *.ll *.ll.s

--- a/fragments/kernel/compile.mk
+++ b/fragments/kernel/compile.mk
@@ -62,7 +62,6 @@ RISCV_CCPPFLAGS += -static
 RISCV_CCPPFLAGS += -ffast-math
 RISCV_CCPPFLAGS += -fno-common
 RISCV_CCPPFLAGS += -ffp-contract=off
-RISCV_CCPPFLAGS += -frerun-cse-after-loop -fweb -frename-registers
 
 RISCV_CFLAGS   += -std=gnu99 $(RISCV_CCPPFLAGS)
 RISCV_CXXFLAGS += -std=c++11 $(RISCV_CCPPFLAGS)

--- a/fragments/kernel/gcc/compile.mk
+++ b/fragments/kernel/gcc/compile.mk
@@ -1,4 +1,4 @@
-RISCV_CCPPFLAGS += -mno-fdiv
+RISCV_CCPPFLAGS += -mno-fdiv -frerun-cse-after-loop -fweb -frename-registers
 
 %.rvo: RISCV_INCLUDES += $(KERNEL_INCLUDES)
 


### PR DESCRIPTION
- change clang compilation makefile to compile using our HB backend
- separate out some compiler flags that are supported by gcc but not by clang
- add to clean rule in vector add to remove llvm intermediate files
- clang compilation can be enabled by adding `_KERNEL_COMPILER=CLANG` to example makefile (or passing it on the command line)