### PR TITLE
(Tiny) Fix of make help output

### DIFF
--- a/examples/conv1d/Makefile
+++ b/examples/conv1d/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/conv2d/Makefile
+++ b/examples/conv2d/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/group_matrix_matrix_multiply/Makefile
+++ b/examples/group_matrix_matrix_multiply/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/hello_world/Makefile
+++ b/examples/hello_world/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/reduction/Makefile
+++ b/examples/reduction/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/tile_circular_buffer/Makefile
+++ b/examples/tile_circular_buffer/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/tile_conv1d/Makefile
+++ b/examples/tile_conv1d/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/tile_matrix_matrix_multiply/Makefile
+++ b/examples/tile_matrix_matrix_multiply/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/tile_memcopy/Makefile
+++ b/examples/tile_memcopy/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/tile_vector_add/Makefile
+++ b/examples/tile_vector_add/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 

--- a/examples/vector_add/Makefile
+++ b/examples/vector_add/Makefile
@@ -123,7 +123,7 @@ clean: cosim.clean analysis.clean cudalite.clean custom.clean
 _HELP_STRING := "Makefile Rules\n"
 
 _HELP_STRING += "    default: \n"
-_HELP_STRING += "        - Run the default kernel ($KERNEL_DEFAULT) and generate all of the\n"
+_HELP_STRING += "        - Run the default kernel ($(KERNEL_DEFAULT)) and generate all of the\n"
 _HELP_STRING += "          analysis products\n"
 default: pc_stats graphs stats
 


### PR DESCRIPTION
Print default kernel version in `make help` output (e.g. print "[...] (kernel/v3/kernel.cpp) [...]" instead of "[...] (ERNEL_DEFAULT) [...]").